### PR TITLE
feat: added ability for users to be able to switch networks without connecting wallet

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/macro'
 import PerpModal from 'components/Perpetual'
 import { SupportedChainId } from 'constants/chains'
+import { lazy, Suspense } from 'react'
 import { useModalOpen, useShowClaimPopup, useTogglePerpModal, useToggleSelfClaimModal } from 'state/application/hooks'
 import { ApplicationModal } from 'state/application/reducer'
 import { useUserHasAvailableClaim } from 'state/claim/hooks'
@@ -20,7 +21,7 @@ import Menu from '../Menu'
 import NavigationLinks from '../NavigationLinks'
 import { Dots } from '../swap/styleds'
 import Web3Status from '../Web3Status'
-import NetworkSelector from './NetworkSelector'
+const NetworkSelector = lazy(() => import('./NetworkSelector'))
 
 const HeaderFrame = styled.div<{ showBackground: boolean }>`
   display: grid;
@@ -240,7 +241,9 @@ export default function Header() {
         <NavigationLinks />
         <HeaderControls>
           <HeaderElement>
-            <NetworkSelector />
+            <Suspense fallback="loading...">
+              <NetworkSelector />
+            </Suspense>
           </HeaderElement>
           <HeaderElement>
             {availableClaim && !showClaimPopup && (

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -20,17 +20,25 @@ const Message = styled.h2`
 
 export default function Web3ReactManager({ children }: { children: JSX.Element }) {
   const { active } = useWeb3React()
-  const { active: networkActive, error: networkError, activate: activateNetwork } = useWeb3React(NetworkContextName)
+  const {
+    active: networkActive,
+    error: networkError,
+    activate: activateNetwork,
+    deactivate: deactivateNetwork,
+  } = useWeb3React(NetworkContextName)
+
+  // since eager connection may fail silently ensure network is already connected first before hand
+  useEffect(() => {
+    if (!networkActive && !networkError && !active) {
+      activateNetwork(network)
+    } else if (networkActive && active) {
+      // deactivate network on connection
+      deactivateNetwork()
+    }
+  }, [networkActive, networkError, activateNetwork, active])
 
   // try to eagerly connect to an injected provider, if it exists and has granted access already
   const triedEager = useEagerConnect()
-
-  // after eagerly trying injected, if the network connect ever isn't active or in an error state, activate itd
-  useEffect(() => {
-    if (triedEager && !networkActive && !networkError && !active) {
-      activateNetwork(network)
-    }
-  }, [triedEager, networkActive, networkError, activateNetwork, active])
 
   // when there's no account connected, react to logins (broadly speaking) on the injected provider, if it exists
   useInactiveListener(!triedEager)

--- a/src/connectors/NetworkConnector.ts
+++ b/src/connectors/NetworkConnector.ts
@@ -171,6 +171,10 @@ export class NetworkConnector extends AbstractConnector {
     return this.currentChainId
   }
 
+  public switchChain(chainId: number): void {
+    this.currentChainId = chainId
+  }
+
   public async getAccount(): Promise<null> {
     return null
   }

--- a/src/hooks/web3.ts
+++ b/src/hooks/web3.ts
@@ -13,7 +13,7 @@ export function useActiveWeb3React() {
 }
 
 export function useEagerConnect() {
-  const { activate, active } = useWeb3React()
+  const { activate, active, error } = useWeb3React()
   const [tried, setTried] = useState(false)
 
   // gnosisSafe.isSafeApp() races a timeout against postMessage, so it delays pageload if we are not in a safe app;

--- a/src/utils/switchToNetwork.ts
+++ b/src/utils/switchToNetwork.ts
@@ -1,6 +1,9 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { hexStripZeros } from '@ethersproject/bytes'
 import { Web3Provider } from '@ethersproject/providers'
+import { AbstractConnector } from '@web3-react/abstract-connector'
+import { useWeb3React } from '@web3-react/core'
+import { NetworkConnector } from 'connectors/NetworkConnector'
 import { CHAIN_INFO, SupportedChainId } from 'constants/chains'
 
 import { addNetwork } from './addNetwork'
@@ -8,6 +11,11 @@ import { addNetwork } from './addNetwork'
 interface SwitchNetworkArguments {
   library: Web3Provider
   chainId?: SupportedChainId
+  connector?: AbstractConnector
+}
+interface SwitchNetworkWithRPCArguments {
+  chainId: SupportedChainId
+  connector: AbstractConnector
 }
 
 // provider.request returns Promise<any>, but wallet_switchEthereumChain must return null or throw
@@ -38,5 +46,19 @@ export async function switchToNetwork({ library, chainId }: SwitchNetworkArgumen
     } else {
       throw error
     }
+  }
+}
+
+//this handles chain switch with network
+export async function switchToNetworkWithRPC({ chainId, connector }: SwitchNetworkWithRPCArguments) {
+  try {
+    if (!connector || !('switchChain' in connector)) {
+      return
+    }
+    ;(connector as NetworkConnector).switchChain(chainId as number)
+
+    return connector
+  } catch (error) {
+    throw error
   }
 }


### PR DESCRIPTION
- moved delayed eagerConnection, such that network connection is first used.
- Updated RPC NetworkConnector with swithNetwork method : it takes chainId as an argument and update object currentChain property with the new chain id
- reactivate web3React Network context with the updated connector 